### PR TITLE
set parent class to PICA::Parser::Base

### DIFF
--- a/lib/PICA/Parser/Plain.pm
+++ b/lib/PICA/Parser/Plain.pm
@@ -11,7 +11,7 @@ use constant END_OF_RECORD      => "\N{LINE FEED}";
 
 use Carp qw(croak);
 
-use parent 'PICA::Parser::Plus';
+use parent 'PICA::Parser::Base';
 
 sub next_record {
     my ($self) = @_;


### PR DESCRIPTION
set parent class to PICA::Parser::Base.

Thanks for refactoring. Nice POD coverage:-)
