### PR TITLE
Feature match

### DIFF
--- a/lib/PICA/Path.pm
+++ b/lib/PICA/Path.pm
@@ -10,7 +10,7 @@ use Scalar::Util qw(reftype);
 use overload '""' => \&stringify;
 
 sub new {
-    my ($class, $path) = @_;
+    my ( $class, $path ) = @_;
 
     confess "invalid pica path" if $path !~ /
         ([012.][0-9.][0-9.][A-Z@.]) # tag
@@ -24,36 +24,38 @@ sub new {
     my $subfield   = defined $5 ? "[$5]" : "[_A-Za-z0-9]";
 
     my @position;
-    if (defined $6) { # from, to
-        my ($from, $dash, $to, $length) = ($7, $8, $9, 0);
+    if ( defined $6 ) {    # from, to
+        my ( $from, $dash, $to, $length ) = ( $7, $8, $9, 0 );
 
         if ($dash) {
-            confess "invalid pica path" unless defined($from // $to); # /-
+            confess "invalid pica path" unless defined( $from // $to );   # /-
         }
 
-        if (defined $to) {
-            if (!$from and $dash) { # /-X
+        if ( defined $to ) {
+            if ( !$from and $dash ) {    # /-X
                 $from = 0;
             }
             $length = $to - $from + 1;
-        } else {
+        }
+        else {
             if ($8) {
                 $length = undef;
-            } else {
+            }
+            else {
                 $length = 1;
             }
         }
 
-        if (!defined $length or $length >= 1) {
-            unless (!$from and !defined $length) { # /0-
-                @position = ($from, $length);
+        if ( !defined $length or $length >= 1 ) {
+            unless ( !$from and !defined $length ) {    # /0-
+                @position = ( $from, $length );
             }
         }
     }
 
     $field = qr{$field};
-    
-    if (defined $occurrence) {
+
+    if ( defined $occurrence ) {
         $occurrence = qr{$occurrence};
     }
 
@@ -62,19 +64,114 @@ sub new {
     bless [ $field, $occurrence, $subfield, @position ], $class;
 }
 
-sub match_field {
-    my ($self, $field) = @_;
+sub match {
+    my ( $self, $record, $opt_ref ) = @_;
 
-    if ( $field->[0] =~ $self->[0] && 
-        (!$self->[1] || (defined $field->[1] && $field->[1] =~ $self->[1])) ) {
+    my $subfield_regex = $self->[2];
+    my $split          = $opt_ref->{'split'} // 0;
+    my $join_char      = $opt_ref->{'join'} // '';
+    my $pluck          = $opt_ref->{'pluck'} // 0;
+    my $value_set      = $opt_ref->{'value'} // undef;
+    my $nested_arrays  = $opt_ref->{'nested_arrays'} // 0;
+
+# Do an implicit split for nested_arrays , except when no-implicit-split is set
+    if ( $nested_arrays == 1 ) {
+        $split = 1 unless $opt_ref->{'no-implicit-split'};
+    }
+
+    my $values;
+
+    for my $field ( @{ $self->record_fields($record) } ) {
+        next if not defined $field;
+
+        my $value;
+
+        if ($value_set) {
+            for ( my $i = 2; $i < @{$field}; $i += 2 ) {
+                if ( $field->[$i] =~ $subfield_regex ) {
+                    $value = $value_set;
+                    last;
+                }
+            }
+        }
+        else {
+            $value = [];
+
+            if ($pluck) {
+                push( @$value,
+                    ( $self->match_subfields( $field, { pluck => 1 } ) ) );
+            }
+            else {
+                push( @$value, ( $self->match_subfields($field) ) );
+            }
+            if (@$value) {
+                if ( !$split ) {
+                    my @defined_values = grep { defined($_) } @$value;
+                    $value = join $join_char, @defined_values;
+                }
+            }
+            else {
+                $value = undef;
+            }
+        }
+        if ( defined $value ) {
+            if ($split) {
+                $value = [$value]
+                    unless ( defined($value) && ref($value) eq 'ARRAY' );
+                if ( defined($values) && ref($values) eq 'ARRAY' ) {
+
+                    # With the nested arrays option a split will
+                    # always return an array of array of values.
+                    if ( $nested_arrays == 1 ) {
+                        push @$values, $value;
+                    }
+                    else {
+                        push @$values, @$value;
+                    }
+                }
+                else {
+                    if ( $nested_arrays == 1 ) {
+                        $values = [$value];
+                    }
+                    else {
+                        $values = [@$value];
+                    }
+                }
+            }
+            else {
+                push @$values, $value;
+            }
+        }
+    }
+
+    if ( $split && defined $values ) {
+        $values = $values;
+    }
+    elsif ( defined $values ) {
+        $values = join $join_char, @$values;
+    }
+    else {
+        # no result
+    }
+    return $values;
+}
+
+sub match_field {
+    my ( $self, $field ) = @_;
+
+    if ($field->[0] =~ $self->[0]
+        && ( !$self->[1]
+            || ( defined $field->[1] && $field->[1] =~ $self->[1] ) )
+        )
+    {
         return $field;
     }
 
-    return
+    return;
 }
 
 sub match_subfields {
-    my ($self, $field) = @_;
+    my ( $self, $field, $opt_ref ) = @_;
 
     my $subfield_regex = $self->[2];
     my $from           = $self->[3];
@@ -82,15 +179,44 @@ sub match_subfields {
 
     my @values;
 
-    for (my $i = 2; $i < @$field; $i += 2) {
-        if ($field->[$i] =~ $subfield_regex) {
-            my $value = $field->[$i + 1];
-            if (defined $from) {
-                $value = $length ? substr($value, $from, $length) :
-                                   substr($value, $from);
-                next if '' eq ($value // '');
+    if ( $opt_ref->{pluck} ) {
+
+        # Treat the subfields as a hash index
+        my $subfield_href = {};
+        for ( my $i = 2; $i < @{$field}; $i += 2 ) {
+            push @{ $subfield_href->{ $field->[$i] } }, $field->[ $i + 1 ];
+        }
+
+        my $subfields = $self->[2];
+        $subfields =~ s{[^a-zA-Z0-9]}{}g;
+        for my $subfield ( split( '', $subfields ) ) {
+            my $value = $subfield_href->{$subfield} // [undef];
+            if ( defined $from ) {
+                push @values, map {
+                    $length
+                        ? substr( $_, $from, $length )
+                        : substr( $_, $from )
+                } @{$value};
             }
-            push @values, $value;
+            else {
+                push @values, @{$value};
+            }
+
+        }
+    }
+    else {
+        for ( my $i = 2; $i < @$field; $i += 2 ) {
+            if ( $field->[$i] =~ $subfield_regex ) {
+                my $value = $field->[ $i + 1 ];
+                if ( defined $from ) {
+                    $value
+                        = $length
+                        ? substr( $value, $from, $length )
+                        : substr( $value, $from );
+                    next if '' eq ( $value // '' );
+                }
+                push @values, $value;
+            }
         }
     }
 
@@ -98,20 +224,20 @@ sub match_subfields {
 }
 
 sub record_fields {
-    my ($self, $record) = @_;
+    my ( $self, $record ) = @_;
 
     $record = $record->{record} if reftype $record eq 'HASH';
     return [ grep { $self->match_field($_) } @$record ];
 }
 
 sub record_subfields {
-    my ($self, $record) = @_;
+    my ( $self, $record ) = @_;
 
     $record = $record->{record} if reftype $record eq 'HASH';
 
     my @values;
 
-    foreach my $field (grep { $self->match_field($_) } @$record) {
+    foreach my $field ( grep { $self->match_field($_) } @$record ) {
         push @values, $self->match_subfields($field);
     }
 
@@ -119,40 +245,45 @@ sub record_subfields {
 }
 
 sub stringify {
-    my ($self, $short) = @_;
+    my ( $self, $short ) = @_;
 
-    my ($field, $occurrence, $subfields) = map {
-        defined $_ ? do {
+    my ( $field, $occurrence, $subfields ) = map {
+        defined $_
+            ? do {
             s/^\(\?[^:]*:(.*)\)$/$1/;
-             $_ } : undef
-        } ($self->[0], $self->[1], $self->[2]); 
+            $_;
+            }
+            : undef
+    } ( $self->[0], $self->[1], $self->[2] );
 
     my $str = $field;
 
-    if (defined $occurrence) {
+    if ( defined $occurrence ) {
         $str .= "[$occurrence]";
     }
 
-    if (defined $subfields and $subfields ne '[_A-Za-z0-9]') {
+    if ( defined $subfields and $subfields ne '[_A-Za-z0-9]' ) {
         $subfields =~ s/\[|\]//g;
-        unless( $short and $subfields !~  /^\$/ ) {
+        unless ( $short and $subfields !~ /^\$/ ) {
             $str .= '$';
         }
         $str .= $subfields;
     }
 
-    my ($from, $length, $pos) = ($self->[3], $self->[4]);
-    if (defined $from) {
+    my ( $from, $length, $pos ) = ( $self->[3], $self->[4] );
+    if ( defined $from ) {
         if ($from) {
             $pos = $from;
-        }         
-        if (!defined $length) {
+        }
+        if ( !defined $length ) {
             if ($from) {
                 $pos = "$from-";
             }
-        } elsif ($length > 1) {
-            $pos .= '-' . ($from + $length - 1);
-        } elsif ($length == 1 && !$from) {
+        }
+        elsif ( $length > 1 ) {
+            $pos .= '-' . ( $from + $length - 1 );
+        }
+        elsif ( $length == 1 && !$from ) {
             $pos = 0;
         }
     }
@@ -241,20 +372,76 @@ supported.
 
 =back
 
-=head2 match_field( $field )
+=head2 match( $record, \%opts )
 
-Check whether a given PICA field matches the field and occurrence of this path.
-Returns the C<$field> on success.
+Returns matched fields as string or array reference. 
+
+Optional parameter:
+
+=over
+ 
+=item join STRING
+ 
+By default all the matched values are joined into a string without a field 
+separator. Use the join function to set the separator. Default: '' 
+(empty string).
+
+    my $record = { _id => 123X, record => [[ '021A', '', 'a', 'Title', 'd', 'Supplement' ]] }
+    my $path = PICA::Path->new( '021A' );
+    my $match = $path->match($record, { join => ' - '} );
+    is( $match, 'Title - Supplement' )
+ 
+=item pluck 0|1
+ 
+Be default, all subfields are added to the mapping in the order they are 
+found in the record. Using the pluck option, one can select the required 
+order of subfields to map. Default: 0.
+ 
+    my $record = { _id => 123X, record => [[ '021A', '', 'a', 'Title', 'd', 'Supplement' ]] }
+    my $path = PICA::Path->new( '021A' );
+    my $match = $path->match($record, { pluck => 1 } );
+    is( $match, 'SupplementTitle' )
+
+=item split 0|1
+ 
+When split is set to 1 then all mapped values will be joined into an array 
+instead of a string. Default: 0. 
+
+    my $record = { _id => 123X, record => [[ '021A', '', 'a', 'Title', 'd', 'Supplement' ]] }
+    my $path = PICA::Path->new( '021A' );
+    my $match = $path->match( $record, { split => 1} );
+    is_deeply( $match, ['Title', 'Supplement'] )
+
+=item nested_arrays 0|1
+ 
+When the split option is specified the output of the mapping will always be 
+an array of strings (one string for each subfield found). Using the 
+nested_array option the output will be an array of array of strings (one 
+array item for each matched field, one array of strings for each matched 
+subfield). Default: 0.
+
+    my $record = { _id => 123X, record => [[ '045U', '', 'e', '003', 'e', '004' ], [ '045U', '', 'e', '005' ]] }
+    my $path = PICA::Path->new( '045U' );
+    my $match = $path->match($record, { nested_arrays => 1 } );
+    is_deeply( $match, [['003', '004'], ['005']] )
+
+=back
 
 =head2 filter_record_fields( $record )
 
 Returns an array reference with fields of a L<PICA::Data> that match the path.
 Subfield codes are ignore.
 
+=head2 match_field( $field )
+
+Check whether a given PICA field matches the field and occurrence of this path.
+Returns the C<$field> on success.
+
 =head2 match_subfields( $field )
 
 Returns a list of matching subfields (optionally trimmed by from and length)
 without inspection field and occurrence values.
+
 
 =head2 stringify( [ $short ] )
 

--- a/t/16-match.t
+++ b/t/16-match.t
@@ -1,0 +1,320 @@
+use strict;
+use warnings;
+use Test::More;
+
+my $pkg;
+
+BEGIN {
+    $pkg = 'PICA::Path';
+    use_ok $pkg;
+}
+
+require_ok $pkg;
+
+my $record = {
+    record => [
+        [ '005A', '', '0', '1234-5678' ],
+        [ '005A', '', '0', '1011-1213' ],
+        [   '009Q', '', 'u', 'http://example.org/', 'x', 'A', 'z', 'B', 'z',
+            'C'
+        ],
+        [ '021A', '', 'a', 'Title', 'd', 'Supplement' ],
+        [   '031N', '',     'j', '1600', 'k', '1700',
+            'j',    '1800', 'k', '1900', 'j', '2000'
+        ],
+        [ '045F', '01', 'a', '001' ],
+        [ '045F', '02', 'a', '002' ],
+        [ '045U', '', 'e', '003', 'e', '004' ],
+        [ '045U', '', 'e', '005' ]
+    ],
+    _id => 1234
+};
+
+note('Single field, no subfield repetition');
+
+{
+    my $path  = PICA::Path->new('021A');
+    my $match = $path->match($record);
+    is( $match, 'TitleSupplement', 'match field' );
+}
+
+{
+    my $path  = PICA::Path->new('021Aa');
+    my $match = $path->match($record);
+    is( $match, 'Title', 'match subfield' );
+}
+
+{
+    my $path  = PICA::Path->new('021Aad');
+    my $match = $path->match($record);
+    is( $match, 'TitleSupplement', 'match subfields' );
+}
+
+{
+    my $path  = PICA::Path->new('021Ada');
+    my $match = $path->match($record);
+    is( $match, 'TitleSupplement', 'match subfields' );
+}
+
+{
+    my $path = PICA::Path->new('021Ada');
+    my $match = $path->match( $record, { pluck => 1 } );
+    is( $match, 'SupplementTitle', 'match subfields pluck' );
+}
+
+{
+    my $path = PICA::Path->new('021Ada');
+    my $match = $path->match( $record, { pluck => 1, join => ' ' } );
+    is( $match, 'Supplement Title', 'match subfields pluck join' );
+}
+
+{
+    my $path = PICA::Path->new('021A');
+    my $match = $path->match( $record, { split => 1 } );
+    is_deeply( $match, [ 'Title', 'Supplement' ], 'match field split' );
+}
+
+{
+    my $path = PICA::Path->new('021A');
+    my $match = $path->match( $record, { split => 1, nested_arrays => 1 } );
+    is_deeply(
+        $match,
+        [ [ 'Title', 'Supplement' ] ],
+        'match field split nested_arrays'
+    );
+}
+
+note('Single field, repeated subfields');
+
+{
+    my $path  = PICA::Path->new('009Q');
+    my $match = $path->match($record);
+    is( $match, 'http://example.org/ABC', 'match field' );
+}
+
+{
+    my $path  = PICA::Path->new('009Qz');
+    my $match = $path->match($record);
+    is( $match, 'BC', 'match subfield' );
+}
+
+{
+    my $path = PICA::Path->new('009Q');
+    my $match = $path->match( $record, { split => 1 } );
+    is_deeply(
+        $match,
+        [ 'http://example.org/', 'A', 'B', 'C' ],
+        'match field split'
+    );
+}
+
+{
+    my $path = PICA::Path->new('009Qz');
+    my $match = $path->match( $record, { split => 1 } );
+    is_deeply( $match, [ 'B', 'C' ], 'match subfield split' );
+}
+
+{
+    my $path = PICA::Path->new('009Qxz');
+    my $match = $path->match( $record, { split => 1 } );
+    is_deeply( $match, [ 'A', 'B', 'C' ], 'match subfields split' );
+}
+
+{
+    my $path = PICA::Path->new('009Qz');
+    my $match = $path->match( $record, { split => 1, nested_arrays => 1 } );
+    is_deeply(
+        $match,
+        [ [ 'B', 'C' ] ],
+        'match subfield split nested_arrays'
+    );
+}
+
+note('Repeated Field, no subfield repetition');
+
+{
+    my $path  = PICA::Path->new('005A');
+    my $match = $path->match($record);
+    is( $match, '1234-56781011-1213', 'match field' );
+}
+
+{
+    my $path  = PICA::Path->new('005A0');
+    my $match = $path->match($record);
+    is( $match, '1234-56781011-1213', 'match subfield' );
+}
+
+{
+    my $path = PICA::Path->new('005A');
+    my $match = $path->match( $record, { split => 1 } );
+    is_deeply( $match, [ '1234-5678', '1011-1213' ], 'match field split' );
+}
+
+{
+    my $path = PICA::Path->new('005A0');
+    my $match = $path->match( $record, { split => 1 } );
+    is_deeply( $match, [ '1234-5678', '1011-1213' ], 'match subfield split' );
+}
+
+{
+    my $path = PICA::Path->new('005A');
+    my $match = $path->match( $record, { split => 1, nested_arrays => 1 } );
+    is_deeply(
+        $match,
+        [ ['1234-5678'], ['1011-1213'] ],
+        'match field split nested_arrays'
+    );
+}
+
+note('Repeated field with repeated subfields');
+
+{
+    my $path  = PICA::Path->new('045U');
+    my $match = $path->match($record);
+    is( $match, '003004005', 'match field' );
+}
+
+{
+    my $path  = PICA::Path->new('045Ue');
+    my $match = $path->match($record);
+    is( $match, '003004005', 'match subfield' );
+}
+
+{
+    my $path = PICA::Path->new('045U');
+    my $match = $path->match( $record, { split => 1 } );
+    is_deeply( $match, [ '003', '004', '005' ], 'match field split' );
+}
+
+{
+    my $path = PICA::Path->new('045Ue');
+    my $match = $path->match( $record, { split => 1 } );
+    is_deeply( $match, [ '003', '004', '005' ], 'match subfield split' );
+}
+
+{
+    my $path = PICA::Path->new('045U');
+    my $match = $path->match( $record, { split => 1, nested_arrays => 1 } );
+    is_deeply(
+        $match,
+        [ [ '003', '004' ], ['005'] ],
+        'match field split nested_arrays'
+    );
+}
+
+note('Repeated field with occurrence');
+
+{
+    my $path  = PICA::Path->new('045F[01]');
+    my $match = $path->match($record);
+    is( $match, '001', 'match field occurence' );
+}
+
+{
+    my $path = PICA::Path->new('045F[0.]');
+    my $match = $path->match( $record, { split => 1 } );
+    is_deeply( $match, [ '001', '002' ], 'match field occurence split' );
+}
+
+note('Referencing the whole record');
+
+{
+    my $path  = PICA::Path->new('....');
+    my $match = $path->match($record);
+    is( $match,
+        '1234-56781011-1213http://example.org/ABCTitleSupplement16001700180019002000001002003004005',
+        'match field'
+    );
+}
+
+{
+    my $path  = PICA::Path->new('....a');
+    my $match = $path->match($record);
+    is( $match, 'Title001002', 'match subfield' );
+}
+
+{
+    my $path = PICA::Path->new('....');
+    my $match = $path->match( $record, { split => 1 } );
+    is_deeply(
+        $match,
+        [   "1234-5678",           "1011-1213",
+            "http://example.org/", "A",
+            "B",                   "C",
+            "Title",               "Supplement",
+            1600,                  1700,
+            1800,                  1900,
+            2000,                  "001",
+            "002",                 "003",
+            "004",                 "005"
+        ],
+        'match field split'
+    );
+}
+
+{
+    my $path = PICA::Path->new('....a');
+    my $match = $path->match( $record, { split => 1 } );
+    is_deeply( $match, [ "Title", "001", "002" ], 'match subfield split' );
+}
+
+{
+    my $path = PICA::Path->new('....');
+    my $match = $path->match( $record, { split => 1, nested_arrays => 1 } );
+    is_deeply(
+        $match,
+        [   ["1234-5678"],
+            ["1011-1213"],
+            [ "http://example.org/", "A", "B", "C", ],
+            [ "Title",               "Supplement" ],
+            [ 1600, 1700, 1800, 1900, 2000, ],
+            ["001"],
+            ["002"],
+            [ "003", "004" ],
+            ["005"]
+        ],
+        'match field split nested_arrays'
+    );
+}
+
+{
+    my $path = PICA::Path->new('....a');
+    my $match = $path->match( $record, { split => 1, nested_arrays => 1 } );
+    is_deeply(
+        $match,
+        [ ["Title"], ["001"], ["002"] ],
+        'match subfield split nested_arrays'
+    );
+}
+
+note('Subtsring from field');
+
+{
+    my $path  = PICA::Path->new('021A/0-');
+    my $match = $path->match($record);
+    is( $match, 'TitleSupplement', 'match field substring' );
+}
+
+{
+    my $path  = PICA::Path->new('021A/0-1');
+    my $match = $path->match($record);
+    is( $match, 'TiSu', 'match field substring' );
+}
+
+{
+    my $path = PICA::Path->new('021Ada/0-1');
+    my $match = $path->match( $record, { pluck => 1 } );
+    is( $match, 'SuTi', 'match subfields substring pluck' );
+}
+
+{
+    my $path = PICA::Path->new('021Ada/0-');
+    my $match = $path->match( $record, { pluck => 1, split => 1 } );
+    is_deeply(
+        $match,
+        [ 'Supplement', 'Title' ],
+        'match substring subfields pluck split'
+    );
+}
+
+done_testing();


### PR DESCRIPTION
Added a method `match()` to PICA::Path, which supports options like `join`, `pluck`, `split` & `nested_arrays` and returns data like `marc_map()`. Added also a section 'Matching rules' to POD. 

