### PR TITLE
Fix replacement expression in PICA/Path.pm

### DIFF
--- a/lib/PICA/Path.pm
+++ b/lib/PICA/Path.pm
@@ -159,7 +159,7 @@ sub match_subfields {
         }
 
         my $subfields = $self->[2];
-        $subfields =~ s{.*\[(.+)\].*}{\1}g;
+        $subfields =~ s{.*\[(.+)\].*}{$1}g;
         for my $subfield (split('', $subfields)) {
             my $value = $subfield_href->{$subfield} // [undef];
             if (defined $from) {


### PR DESCRIPTION
This commit fix the following error message:

`\1 better written as $1 at /home/nico/perl5/lib/perl5/PICA/Path.pm line 162.`

I'm not an Perl expert, please review this commit carefully.