### PR TITLE
Add Github action workflow for Linux

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,54 @@
+name: linux
+
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ main, dev ]
+  workflow_dispatch:
+    branches: [ '*' ]
+
+jobs:
+  perl:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        perl-version:
+        - '5.14'
+        - '5.16'
+        - '5.18'
+        - '5.20'
+        - '5.22'
+        - '5.24'
+        - '5.26'
+        - '5.28'
+        - '5.30'
+        include:
+          - perl-version: '5.32'
+            os: ubuntu-latest
+            release-test: true
+            coverage: true
+    container:
+      image: perl:${{ matrix.perl-version }}
+    steps:
+    - uses: actions/checkout@v2
+    - run: env | sort
+    - run: perl -V
+    - run: cpanm -n --installdeps .
+    - name: Run release tests
+      if: ${{ matrix.release-test }}
+      run: |
+        cpanm -n Perl::Tidy Test::Code::TidyAll Test::Perl::Critic
+        cpanm -n --installdeps --with-develop .
+        prove -lr xt
+    - name: Run tests (no coverage)
+      if: ${{ !matrix.coverage }}
+      run: prove -lr t
+    - name: Run tests (with coverage)
+      if: ${{ matrix.coverage }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        cpanm -n Devel::Cover::Report::Coveralls
+        perl Build.PL && ./Build build && cover -test -report coveralls

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 PICA::Data - PICA record processing
 
 [![Unix build Status](https://travis-ci.com/gbv/PICA-Data.png)](https://travis-ci.com/gbv/PICA-Data)
+[![Linux build status](https://github.com/gbv/PICA-Data/actions/workflows/linux.yml/badge.svg)](https://github.com/gbv/PICA-Data/actions/workflows/linux.yml)
 [![Windows build status](https://ci.appveyor.com/api/projects/status/5qjak74x7mjy7ne6?svg=true)](https://ci.appveyor.com/project/nichtich/pica-data)
 [![Coverage Status](https://coveralls.io/repos/gbv/PICA-Data/badge.svg)](https://coveralls.io/r/gbv/PICA-Data)
 [![Kwalitee Score](http://cpants.cpanauthors.org/dist/PICA-Data.png)](http://cpants.cpanauthors.org/dist/PICA-Data)

--- a/lib/PICA/Data.pm
+++ b/lib/PICA/Data.pm
@@ -499,6 +499,7 @@ PICA::Data - PICA record processing
 =begin markdown 
 
 [![Unix build Status](https://travis-ci.com/gbv/PICA-Data.png)](https://travis-ci.com/gbv/PICA-Data)
+[![Linux build status](https://github.com/gbv/PICA-Data/actions/workflows/linux.yml/badge.svg)](https://github.com/gbv/PICA-Data/actions/workflows/linux.yml)
 [![Windows build status](https://ci.appveyor.com/api/projects/status/5qjak74x7mjy7ne6?svg=true)](https://ci.appveyor.com/project/nichtich/pica-data)
 [![Coverage Status](https://coveralls.io/repos/gbv/PICA-Data/badge.svg)](https://coveralls.io/r/gbv/PICA-Data)
 [![Kwalitee Score](http://cpants.cpanauthors.org/dist/PICA-Data.png)](http://cpants.cpanauthors.org/dist/PICA-Data)


### PR DESCRIPTION
I've added a first Github action workflow for Linux, see #119. With release testing and coveralls.io integration. Added badge to README and POD.