### PR TITLE
delay loading PICA modules in PICA::Schema to work around circular dependencies

### DIFF
--- a/lib/PICA/Schema.pm
+++ b/lib/PICA/Schema.pm
@@ -6,12 +6,13 @@ our $VERSION = '2.06';
 use Scalar::Util qw(reftype);
 use Storable     qw(dclone);
 use List::Util   qw(pairs);
-use PICA::Data;
-use PICA::Error;
 
 use Exporter 'import';
 our @EXPORT_OK
     = qw(field_identifier check_value clean_pica parse_subfield_schedule);
+
+require PICA::Data;
+require PICA::Error;
 
 sub new {
     my ($class, $schema) = @_;


### PR DESCRIPTION
The various modules in this dist have circular dependencies between them. This would result in PICA::Patch failing to import subs from PICA::Schema, because the sub and exporting was not set up yet by the time it would try to import. Perl would ignore the call to import when the method didn't exist.

Delay loading the other PICA modules until after all parsing has been completed and exporting is set up.

Future versions of perl are intending to throw errors when passing arguments to an undefined import method, which causes test failures. This also helped reveal the broken import.